### PR TITLE
Draft for timers API

### DIFF
--- a/domain-logic/index.ts
+++ b/domain-logic/index.ts
@@ -32,7 +32,7 @@ const onResult = (
 const success = (r: any) => ({ success: true, data: r } as Result)
 const error = (r: Errors) => ({ success: false, errors: r } as Result)
 
-const ALL_TRANSPORTS = ['http', 'websocket', 'terminal', 'notification'] as const
+const ALL_TRANSPORTS = ['http', 'websocket', 'terminal', 'notification', 'timer'] as const
 type Transport = typeof ALL_TRANSPORTS[number]
 
 type Action = {
@@ -68,6 +68,7 @@ const makeAction = zipObject(ALL_TRANSPORTS, allHelpers)
 
 const { query, mutation } = makeAction.http
 const { mutation: notifyMutation } = makeAction.notification
+const { mutation: timerMutation } = makeAction.timer
 
 const publish = publishInNamespace('tasks')
 
@@ -107,6 +108,11 @@ const tasks: Actions = {
     console.log('deliver-completed-notifications event handler received: ', { input })
     return success(null)
   }),
+  'deliver-reminder-notifications': timerMutation((input: any) => {
+    console.log('deliver-reminder-notifications event handler received: ', { input })
+    return success(null)
+  }),
+
   'clear-completed': mutation(async () => {
     await prisma.task.deleteMany({
       where: { completed: true },

--- a/jobs/package.json
+++ b/jobs/package.json
@@ -16,12 +16,14 @@
     "domain-logic": "link:../domain-logic",
     "fastify": "^3.9.2",
     "fastify-postgres": "^3.3.0",
+    "node-schedule": "^2.0.0",
     "pg": "^8.5.1",
     "pg-listen": "^1.7.0",
     "prisma": "^2.22.1"
   },
   "devDependencies": {
     "@types/node": "^15.3.0",
+    "@types/node-schedule": "^1.3.1",
     "typescript": "^4.2.4"
   }
 }

--- a/jobs/schedule.ts
+++ b/jobs/schedule.ts
@@ -1,0 +1,12 @@
+import { ScheduledJob, scheduleEveryXSeconds, scheduleJobs } from './timer'
+
+const jobs: ScheduledJob[] = [
+  scheduleEveryXSeconds(10)('tasks', 'deliver-reminder-notifications')
+]
+
+const schedule = () => {
+  const scheduledJobs = scheduleJobs(jobs)
+  console.log("\nScheduling jobs:\n", { scheduledJobs })
+}
+
+export default schedule

--- a/jobs/server.ts
+++ b/jobs/server.ts
@@ -7,7 +7,7 @@ import { exit } from 'process'
 import { onResult, Action, findAction } from 'domain-logic'
 import isNil from 'lodash/isNil'
 import split from 'lodash/split'
-import { ScheduledJob, scheduleEveryXSeconds, scheduleJobs } from './timer'
+import schedule from './schedule'
 
 if (process.env.CHANNEL === undefined) {
   console.error("Please provide a value for CHANNEL environment variable")
@@ -64,11 +64,7 @@ const connectPgListener = async () => {
 }
 
 // Timer jobs
-const jobs: ScheduledJob[] = [
-  scheduleEveryXSeconds(10)('tasks', 'deliver-reminder-notifications')
-]
-const scheduledJobs = scheduleJobs(jobs)
-console.log("\nScheduling jobs:\n", { scheduledJobs })
+schedule()
 
 const server = fastify({ logger: true })
 

--- a/jobs/server.ts
+++ b/jobs/server.ts
@@ -7,6 +7,7 @@ import { exit } from 'process'
 import { onResult, Action, findAction } from 'domain-logic'
 import isNil from 'lodash/isNil'
 import split from 'lodash/split'
+import { ScheduledJob, scheduleEveryXSeconds, scheduleJobs } from './timer'
 
 if (process.env.CHANNEL === undefined) {
   console.error("Please provide a value for CHANNEL environment variable")
@@ -61,6 +62,13 @@ const connectPgListener = async () => {
   await subscriber.connect()
   await subscriber.listenTo(channel)
 }
+
+// Timer jobs
+const jobs: ScheduledJob[] = [
+  scheduleEveryXSeconds(10)('tasks', 'deliver-reminder-notifications')
+]
+const scheduledJobs = scheduleJobs(jobs)
+console.log("\nScheduling jobs:\n", { scheduledJobs })
 
 const server = fastify({ logger: true })
 

--- a/jobs/timer.ts
+++ b/jobs/timer.ts
@@ -79,9 +79,6 @@ const scheduleAction:
 
 const scheduleEveryXSeconds = compose(scheduleAction, everyXSeconds)
 
-const jobs: ScheduledJob[] = [
-    scheduleEveryXSeconds(360)('tasks', 'deliver-reminder-notifications')
-]
 
 const scheduleJobs: (allJobs: ScheduledJob[]) => Job[] =
     map(

--- a/jobs/timer.ts
+++ b/jobs/timer.ts
@@ -1,0 +1,95 @@
+import { Action, findAction } from 'domain-logic'
+import isNil from 'lodash/isNil'
+import reduce from 'lodash/reduce'
+import compose from 'lodash/fp/compose'
+import map from 'lodash/fp/map'
+import { Job, scheduleJob } from 'node-schedule'
+
+
+type ScheduleUnit = { kind: 'every', unit?: number } | { kind: 'on', unit?: number }
+
+// Constructors
+const every: (unit?: number) => ScheduleUnit =
+    (unit) => ({ kind: 'every', unit })
+
+const on: (unit?: number) => ScheduleUnit =
+    (unit) => ({ kind: 'on', unit })
+
+// Destructor
+const scheduleUnitToString: (scheduleUnit: ScheduleUnit) => string =
+    (scheduleUnit) => (
+        isNil(scheduleUnit.unit) ?
+            '*' :
+            (
+                scheduleUnit.kind === 'every' ?
+                    `*/${scheduleUnit.unit}` :
+                    `${scheduleUnit.unit}`)
+    )
+
+type Schedule = {
+    second: ScheduleUnit,
+    minute: ScheduleUnit,
+    hour: ScheduleUnit,
+    dayOfMonth: ScheduleUnit,
+    month: ScheduleUnit,
+    dayOfWeek: ScheduleUnit
+}
+
+// Constructors
+const everyXSeconds: (second: number) => Schedule =
+    (second) => ({
+        second: every(second),
+        minute: every(),
+        hour: every(),
+        dayOfMonth: every(),
+        month: every(),
+        dayOfWeek: every()
+    })
+
+// Destructors
+const scheduleToString: (schedule: Schedule) => string =
+    (schedule) => reduce(schedule, (memo, value) => (memo + scheduleUnitToString(value) + ' '), '')
+
+type ScheduledJob = {
+    name: string,
+    schedule: Schedule,
+    action: Action
+}
+
+// Constructors
+const scheduleAction:
+    (schedule: Schedule) =>
+        (namespace: string, actionName: string) =>
+            ScheduledJob =
+    (schedule: Schedule) =>
+        (namespace: string, actionName: string, actionParameters?: any) => {
+            const maybeAction = findAction('timer')(namespace, actionName)
+
+            if (isNil(maybeAction)) {
+                throw "ActionNotFound"
+            }
+            else {
+                return ({
+                    name: `${actionName}@${namespace}@${scheduleToString(schedule)}`,
+                    schedule,
+                    action: maybeAction
+                })
+            }
+        }
+
+const scheduleEveryXSeconds = compose(scheduleAction, everyXSeconds)
+
+const jobs: ScheduledJob[] = [
+    scheduleEveryXSeconds(360)('tasks', 'deliver-reminder-notifications')
+]
+
+const scheduleJobs: (allJobs: ScheduledJob[]) => Job[] =
+    map(
+        (s) => {
+            const j = scheduleJob(s.name, scheduleToString(s.schedule), s.action.action)
+            console.log(s.name, j)
+            return j
+        }
+    )
+
+export { ScheduledJob, scheduleEveryXSeconds, scheduleJobs }

--- a/jobs/tsconfig.json
+++ b/jobs/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     /* Basic Options */

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,6 +775,13 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
+"@types/node-schedule@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node-schedule/-/node-schedule-1.3.1.tgz#6785ea71b12b0b8899c3fce0650b2ef5a7ea9d1e"
+  integrity sha512-xAY/ZATrThUkMElSDfOk+5uXprCrV6c6GQ5gTw3U04qPS6NofE1dhOUW+yrOF2UyrUiAax/Zc4WtagrbPAN3Tw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^15.3.0":
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.1.tgz#23a06b87eedb524016616e886b116b8fdcb180af"
@@ -1901,6 +1908,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cron-parser@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-3.5.0.tgz#b1a9da9514c0310aa7ef99c2f3f1d0f8c235257c"
+  integrity sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==
+  dependencies:
+    is-nan "^1.3.2"
+    luxon "^1.26.0"
 
 croods@^2.2.0:
   version "2.2.0"
@@ -3631,7 +3646,7 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-nan@^1.2.1:
+is-nan@^1.2.1, is-nan@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
   integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
@@ -4556,6 +4571,11 @@ lodash@4.17.21, lodash@4.x, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+long-timeout@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
+  integrity sha1-lyHXiLR+C8taJMLivuGg2lXatRQ=
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -4569,6 +4589,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^1.26.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.27.0.tgz#ae10c69113d85dab8f15f5e8390d0cbeddf4f00f"
+  integrity sha512-VKsFsPggTA0DvnxtJdiExAucKdAnwbCCNlMM5ENvHlxubqWd0xhZcdb4XgZ7QFNhaRhilXCFxHuoObP5BNA4PA==
 
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
@@ -4914,6 +4939,15 @@ node-releases@^1.1.69, node-releases@^1.1.71:
   version "1.1.72"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
   integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
+
+node-schedule@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-2.0.0.tgz#73ab4957d056c63708409cc1fab676e0e149c191"
+  integrity sha512-cHc9KEcfiuXxYDU+HjsBVo2FkWL1jRAUoczFoMIzRBpOA4p/NRHuuLs85AWOLgKsHtSPjN8csvwIxc2SqMv+CQ==
+  dependencies:
+    cron-parser "^3.1.0"
+    long-timeout "0.1.1"
+    sorted-array-functions "^1.3.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -6321,6 +6355,11 @@ sonic-boom@^1.0.2:
   dependencies:
     atomic-sleep "^1.0.0"
     flatstr "^1.0.12"
+
+sorted-array-functions@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
+  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
This PR aims to:
* Define a type-safe API to schedule jobs that abstracts the internals of the chosen library, allowing us to replace `node-schedule` without breaking backwards compatibility.
* Avoid using external state stores (such as [agenda](https://github.com/agenda/agenda)). In case we need external state that should be kept in the same PostgreSQL data store as the domain data (although we should namespace that).
* Provide first combinators that consume `Action` (from `domain-logic`) and `Schedule` (from `jobs`) to create a `Job` (from [node-schedule](https://github.com/node-schedule/node-schedule))
* Implement and example of recurring job