### PR TITLE
Making domain logic browser safe

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+  }

--- a/README.md
+++ b/README.md
@@ -35,29 +35,29 @@ You will find in the `domain-logic/messages/index.ts` file an empty domain calle
 ```ts
 import { exportDomain } from '../prelude'
 
-const messages = exportDomain({})
+const messages = exportDomain('messages', {})
 export { messages }
 ```
 
 Then import some useful function from prelude inside `domain-logic/messages/index.ts` so we can build your first action:
 
 ```ts
-import { exportDomain, makeAction, success } from '../prelude'
+import { exportDomain, makeAction } from '../prelude'
 ```
 
 After that we can get our action constructor for the `http` transport, since our first action will be a simple hello world that takes no parameters over a HTTP `GET` call.
 You can destructure http action constructor by using the line:
 
 ```ts
-const { query } = makeAction('messages').http
+const { query } = makeAction.http
 ```
 
 Note that there are always 2 kinds of constructors, `query` and `mutation`.
 The next step is to call the constructor and store a key named after your action inside the `messages` domain:
 
 ```ts
-const messages = exportDomain({
-  hello: query()(() => success({ message: 'Hello World' })),
+const messages = exportDomain('messages', {
+  hello: query()(async () => ({ message: 'Hello World' })),
 })
 ```
 
@@ -66,10 +66,10 @@ Export at the end of the file the object that you have built with the actions.
 The entire file `domain-logic/messages/index.ts` should look like this:
 
 ```ts
-import { exportDomain, makeAction, success } from '../prelude'
-const { query } = makeAction('messages').http
-const messages = exportDomain({
-  hello: query()(() => success({ message: 'Hello World' })),
+import { exportDomain, makeAction } from '../prelude'
+const { query } = makeAction.http
+const messages = exportDomain('messages', {
+  hello: query()(async () => ({ message: 'Hello World' })),
 })
 export { messages }
 ```

--- a/domain-logic/index.ts
+++ b/domain-logic/index.ts
@@ -1,9 +1,10 @@
 import { findActionInDomain, onAction } from './prelude'
 import { tasks } from './tasks'
+import { messages } from './messages'
 import type { Action } from './prelude'
 import type { Task } from './tasks'
 
-const rules = { tasks }
+const rules = { tasks, messages }
 
 const findAction = findActionInDomain(rules)
 

--- a/domain-logic/messages/index.ts
+++ b/domain-logic/messages/index.ts
@@ -1,20 +1,9 @@
-import { makeAction, exportDomain, serverOrBrowser } from '../prelude'
+import { makeAction, exportDomain } from '../prelude'
 
-const { query } = makeAction('messages').http
+const { query } = makeAction.http
 
-const messages = exportDomain({
-  hello: query<string>()(async () => {
-    serverOrBrowser(
-      () => {
-        console.log('>>>>>>>>>>>>>>>>> SERVER')
-      },
-      () => {
-        console.log('>>>>>>>>>>>>>>>>> BROWSER')
-      }
-    )
-
-    return 'Hello world'
-  }),
+const messages = exportDomain('messages', {
+  hello: query<string>()(async () => 'Hello'),
 })
 
 export { messages }

--- a/domain-logic/messages/index.ts
+++ b/domain-logic/messages/index.ts
@@ -1,9 +1,20 @@
-import { makeAction, exportDomain } from '../prelude'
+import { makeAction, exportDomain, serverOrBrowser } from '../prelude'
 
 const { query } = makeAction('messages').http
 
 const messages = exportDomain({
-  hello: query<string>()(async () => 'Hello world'),
+  hello: query<string>()(async () => {
+    serverOrBrowser(
+      () => {
+        console.log('>>>>>>>>>>>>>>>>> SERVER')
+      },
+      () => {
+        console.log('>>>>>>>>>>>>>>>>> BROWSER')
+      }
+    )
+
+    return 'Hello world'
+  }),
 })
 
 export { messages }

--- a/domain-logic/prelude.ts
+++ b/domain-logic/prelude.ts
@@ -52,10 +52,10 @@ type Actions = Record<string, Action>
 type DomainActions = Record<string, Actions>
 
 const findActionInDomain =
-  (rules: DomainActions) =>
+  <T extends DomainActions, U extends keyof T>(rules: T) =>
   (transport: Transport) =>
-  (namespace: string, actionName: string): Action | undefined => {
-    const action = rules[namespace]?.[actionName]
+  (namespace: U, actionName: string): Action | undefined => {
+    const action = rules[namespace][actionName]
     return action && (action.transport === transport ? action : undefined)
   }
 

--- a/domain-logic/prelude.ts
+++ b/domain-logic/prelude.ts
@@ -82,13 +82,7 @@ const exportDomain = <T extends Actions>(namespace: string, domain: T): T => {
                 }
               : {}
           )
-          try {
-            const json = await result.json()
-            JSON.parse(json)
-            return json
-          } catch (err) {
-            return result
-          }
+          return await result.json()
         }
       )
     }

--- a/domain-logic/prelude.ts
+++ b/domain-logic/prelude.ts
@@ -1,13 +1,5 @@
 import { z, ZodTypeAny } from 'zod'
-import { PrismaClient } from '@prisma/client'
 import zipObject from 'lodash/zipObject'
-import { makePrismaPublisher } from './publisher'
-
-const prisma = new PrismaClient()
-const databasePublihserChannel: string =
-  process.env.CHANNEL ?? 'database-publisher-channel'
-
-const publishInNamespace = makePrismaPublisher(prisma, databasePublihserChannel)
 
 const ALL_TRANSPORTS = [
   'http',
@@ -31,7 +23,7 @@ const allHelpers = (namespace: string) =>
     query:
       <O, P extends ZodTypeAny | undefined = undefined>(parser?: P) =>
       (
-        run: (input: P extends ZodTypeAny ? z.infer<P> : void) => Promise<O>,
+        run: (input: P extends ZodTypeAny ? z.infer<P> : void) => Promise<O>
       ) => ({
         transport: el,
         mutation: false,
@@ -43,7 +35,7 @@ const allHelpers = (namespace: string) =>
     mutation:
       <O, P extends ZodTypeAny | undefined = undefined>(parser?: P) =>
       (
-        run: (input: P extends ZodTypeAny ? z.infer<P> : void) => Promise<O>,
+        run: (input: P extends ZodTypeAny ? z.infer<P> : void) => Promise<O>
       ) => ({
         transport: el,
         mutation: true,
@@ -71,7 +63,7 @@ const onAction =
   <T extends Action>(
     { parser, run }: T,
     onError: (r: any) => any,
-    onSuccess: (r: any) => any,
+    onSuccess: (r: any) => any
   ) =>
   async (input?: ZodTypeAny): Promise<any> => {
     try {
@@ -91,11 +83,14 @@ const exportDomain = <T extends NamedRecord>(domain: T): T => {
   return domain
 }
 
+const serverOrBrowser = (server: () => unknown, browser: () => unknown) =>
+  typeof window === 'undefined' ? server() : browser()
+
 export {
   exportDomain,
   findActionInDomain,
   makeAction,
   onAction,
-  publishInNamespace,
+  serverOrBrowser,
 }
 export type { Action }

--- a/domain-logic/publisher.ts
+++ b/domain-logic/publisher.ts
@@ -2,12 +2,12 @@ import { PrismaClient } from '@prisma/client'
 import merge from 'lodash/merge'
 
 const makePrismaPublisher =
-  (prismaClient: PrismaClient, dbChannel: string) =>
+  (prismaClient: () => PrismaClient, dbChannel: string) =>
   (namespace: string) =>
   async (actionName: string, payload: any): Promise<void> => {
-    await prismaClient.$executeRaw`SELECT pg_notify(${dbChannel}, ${merge(
+    await prismaClient().$executeRaw`SELECT pg_notify(${dbChannel}, ${merge(
       {},
-      { payload, channel: `${actionName}@${namespace}` },
+      { payload, channel: `${actionName}@${namespace}` }
     )})`
   }
 

--- a/domain-logic/tasks/index.ts
+++ b/domain-logic/tasks/index.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod'
 import { Prisma, PrismaClient } from '@prisma/client'
-import { makeAction, exportDomain } from '../prelude'
+import { makeAction, exportDomain, serverOrBrowser } from '../prelude'
 import { makePrismaPublisher } from '../publisher'
 
-const prisma = new PrismaClient()
+const prisma = () =>
+  serverOrBrowser(
+    () => new PrismaClient(),
+    () => {
+      throw new Error('Prisma can only be used in the server')
+    }
+  )
 
 const taskCreateParser = z.object({ text: z.string() })
 const taskDeleteParser = z.object({ id: z.string() })
@@ -13,9 +19,9 @@ const taskUpdateParser = z.object({
   completed: z.boolean().optional(),
 })
 
-const { query, mutation } = makeAction('tasks').http
-const { mutation: notifyMutation } = makeAction('tasks').notification
-const { mutation: timerMutation } = makeAction('tasks').timer
+const { query, mutation } = makeAction.http
+const { mutation: notifyMutation } = makeAction.notification
+const { mutation: timerMutation } = makeAction.timer
 
 const databasePublisherChannel: string =
   process.env.CHANNEL ?? 'database-publisher-channel'
@@ -23,17 +29,17 @@ const databasePublisherChannel: string =
 const publishInNamespace = makePrismaPublisher(prisma, databasePublisherChannel)
 const publish = publishInNamespace('tasks')
 
-const tasks = exportDomain({
+const tasks = exportDomain('tasks', {
   post: mutation<Task, typeof taskCreateParser>(taskCreateParser)(
-    async (input) => prisma.task.create({ data: input })
+    async (input) => prisma().task.create({ data: input })
   ),
-  get: query<Task[]>()(async () => prisma.task.findMany()),
+  get: query<Task[]>()(async () => prisma().task.findMany()),
   delete: mutation<Task, typeof taskDeleteParser>(taskDeleteParser)(
-    async (input) => prisma.task.delete({ where: input })
+    async (input) => prisma().task.delete({ where: input })
   ),
   put: mutation<Task, typeof taskUpdateParser>(taskUpdateParser)(
     async (input) =>
-      prisma.task.update({ where: { id: input.id }, data: input })
+      prisma().task.update({ where: { id: input.id }, data: input })
   ),
   'send-completed-notifications': query<void>()(async () => {
     const payload = { hello: 'world', superExpensiveOperation: true }
@@ -54,10 +60,10 @@ const tasks = exportDomain({
     }
   ),
   'clear-completed': mutation<Task[]>()(async () => {
-    await prisma.task.deleteMany({
+    await prisma().task.deleteMany({
       where: { completed: true },
     })
-    return prisma.task.findMany()
+    return prisma().task.findMany()
   }),
 })
 

--- a/jobs/server.ts
+++ b/jobs/server.ts
@@ -30,20 +30,23 @@ const subscriber = createSubscriber({ connectionString: databaseURL })
 subscriber.notifications.on(channel, async (msg) => {
   // Payload as passed to subscriber.notify() (see below)
   console.log(`Received notification in '${channel}':`, msg)
-  const [requestedAction, namespace] = split(msg.channel, '@')
+  const [requestedAction, namespace] = split(msg.channel, '@') as [
+    string,
+    'tasks' | 'messages'
+  ]
   const maybeRequestedAction = findAction('notification')(
     namespace,
-    requestedAction,
+    requestedAction
   )
   if (isNil(maybeRequestedAction)) {
     console.error(
-      `Could not find action ${requestedAction} in ${namespace}. Ensure the action transport is set to 'notification'`,
+      `Could not find action ${requestedAction} in ${namespace}. Ensure the action transport is set to 'notification'`
     )
   } else {
     return onAction(
       maybeRequestedAction,
       (errors) => console.error({ errors }),
-      (data) => console.log({ data }),
+      (data) => console.log({ data })
     )(msg.payload)
   }
 })
@@ -86,7 +89,7 @@ const start = async () => {
   try {
     await server.listen(3001)
     server.log.info(
-      `server listening on ${(server.server.address() as AddressInfo)?.port}`,
+      `server listening on ${(server.server.address() as AddressInfo)?.port}`
     )
   } catch (err) {
     server.log.error(err)

--- a/jobs/timer.ts
+++ b/jobs/timer.ts
@@ -19,7 +19,7 @@ const on: (unit?: number) => ScheduleUnit = (unit) => ({ kind: 'on', unit })
 
 // Destructor
 const scheduleUnitToString: (scheduleUnit: ScheduleUnit) => string = (
-  scheduleUnit,
+  scheduleUnit
 ) =>
   isNil(scheduleUnit.unit)
     ? '*'
@@ -51,7 +51,7 @@ const scheduleToString: (schedule: Schedule) => string = (schedule) =>
   reduce(
     schedule,
     (memo, value) => memo + scheduleUnitToString(value) + ' ',
-    '',
+    ''
   )
 
 type ScheduledJob = {
@@ -62,10 +62,14 @@ type ScheduledJob = {
 
 // Constructors
 const scheduleAction: (
-  schedule: Schedule,
-) => (namespace: string, actionName: string) => ScheduledJob =
+  schedule: Schedule
+) => (namespace: 'tasks' | 'messages', actionName: string) => ScheduledJob =
   (schedule: Schedule) =>
-  (namespace: string, actionName: string, actionParameters?: any) => {
+  (
+    namespace: 'tasks' | 'messages',
+    actionName: string,
+    actionParameters?: any
+  ) => {
     const maybeAction = findAction('timer')(namespace, actionName)
 
     if (isNil(maybeAction)) {

--- a/ui/components/filter-menu.tsx
+++ b/ui/components/filter-menu.tsx
@@ -9,11 +9,11 @@ interface ILinkProps {
 
 const FilterLink = ({ filter, active }: ILinkProps) => (
   <li>
-    <Link href={`/${filter}`}>
+    <Link href={`/tasks/${filter}`}>
       <a
         className={cx(
           active && 'border-red-600 dark:border-green-600',
-          'p-1 px-2 rounded border hover:border-red-700 dark:hover:border-green-500 border-transparent text-current',
+          'p-1 px-2 rounded border hover:border-red-700 dark:hover:border-green-500 border-transparent text-current'
         )}
       >
         {startCase(filter)}

--- a/ui/pages/api/croods/[...actionPath].ts
+++ b/ui/pages/api/croods/[...actionPath].ts
@@ -11,15 +11,19 @@ const makeHandler =
       res.setHeader('Allow', 'POST, PATCH, PUT, DELETE')
       return res.status(405).end()
     }
+
     return onAction(
       action,
       (errors) => res.status(500).json({ errors, input }),
-      (data) => res.status(200).json(data),
+      (data) => res.status(200).json(JSON.stringify(data))
     )(input)
   }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const [namespace, requestedAction] = req.query.actionPath as string[]
+  const [namespace, requestedAction] = req.query.actionPath as [
+    'tasks' | 'messages',
+    string
+  ]
   const maybeRequestedAction = findHttpAction(namespace, requestedAction)
   const maybeResolvedAction =
     maybeRequestedAction || findHttpAction(namespace, req.method!.toLowerCase())

--- a/ui/pages/home.tsx
+++ b/ui/pages/home.tsx
@@ -5,15 +5,16 @@ import { useEffect, useState } from 'react'
 export default function HomePage({
   message,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [data, setData] = useState("");
+  const [data, setData] = useState('')
 
   useEffect(() => {
     const fetchData = async () => {
       const msg = await messages.hello.run()
+      console.log({ msg })
       setData(msg)
     }
     fetchData()
-  }, [data])
+  }, [])
 
   return (
     <div>

--- a/ui/pages/home.tsx
+++ b/ui/pages/home.tsx
@@ -1,12 +1,24 @@
 import { InferGetStaticPropsType } from 'next'
 import { messages } from '../../domain-logic/messages'
+import { useEffect, useState } from 'react'
 
 export default function HomePage({
   message,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const [data, setData] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const msg = await messages.hello.run()
+      setData(msg)
+    }
+    fetchData()
+  }, [data])
+
   return (
     <div>
       <h1>{message}</h1>
+      <h1>{data}</h1>
     </div>
   )
 }

--- a/ui/pages/tasks/[filter].tsx
+++ b/ui/pages/tasks/[filter].tsx
@@ -15,15 +15,7 @@ export default function TodosPage({
   filter,
   allTasks,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const addTask = (payload: { text: string }) => {
-    fetch('/api/croods/tasks/post', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    })
-  }
-
-  const clearCompleted = () =>
-    fetch('/api/croods/tasks/clear-completed', { method: 'POST' })
+  const addTask = (payload: { text: string }) => tasks.post.run(payload)
 
   return (
     <div className="layout">
@@ -50,17 +42,9 @@ export default function TodosPage({
                   key={`task-${idx}`}
                   task={task}
                   update={({ text, completed }: Partial<Task>) =>
-                    fetch('/api/croods/tasks/put', {
-                      method: 'POST',
-                      body: JSON.stringify({ id: task.id, text, completed }),
-                    })
+                    tasks.put.run({ id: task.id!, text, completed })
                   }
-                  destroy={() =>
-                    fetch('/api/croods/tasks/delete', {
-                      method: 'POST',
-                      body: JSON.stringify({ id: task.id }),
-                    })
-                  }
+                  destroy={() => tasks.delete.run({ id: task.id! })}
                 />
               ))}
           </ul>
@@ -69,7 +53,7 @@ export default function TodosPage({
           filters={FILTERS}
           current={filter}
           tasks={allTasks}
-          clearAll={clearCompleted}
+          clearAll={() => tasks['clear-completed'].run()}
         />
       </section>
       <FooterInfo />
@@ -77,15 +61,13 @@ export default function TodosPage({
   )
 }
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: FILTERS.map((filter) => ({ params: { filter } })),
-    fallback: false,
-  }
-}
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: FILTERS.map((filter) => ({ params: { filter } })),
+  fallback: false,
+})
 
 export const getStaticProps = async (
-  context: GetStaticPropsContext<{ filter: string }>,
+  context: GetStaticPropsContext<{ filter: string }>
 ) => {
   const allTasks = await tasks.get.run()
 


### PR DESCRIPTION
We cannot instantiate prisma in the browser, so no import used in the client-side can have a prisma instance, we stated by removing from the prelude