### PR TITLE
Minimal websockets wiring

### DIFF
--- a/jobs/package.json
+++ b/jobs/package.json
@@ -17,6 +17,7 @@
     "domain-logic": "link:../domain-logic",
     "fastify": "^3.19.0",
     "fastify-postgres": "^3.5.0",
+    "fastify-websocket": "^3.2.0",
     "node-schedule": "^2.0.0",
     "pg": "^8.6.0",
     "pg-listen": "^1.7.0"

--- a/jobs/schedule.ts
+++ b/jobs/schedule.ts
@@ -1,12 +1,12 @@
 import { ScheduledJob, scheduleEveryXSeconds, scheduleJobs } from './timer'
 
 const jobs: ScheduledJob[] = [
-  scheduleEveryXSeconds(10)('tasks', 'deliver-reminder-notifications')
+  // scheduleEveryXSeconds(10)('tasks', 'deliver-reminder-notifications')
 ]
 
 const schedule = () => {
   const scheduledJobs = scheduleJobs(jobs)
-  console.log("\nScheduling jobs:\n", { scheduledJobs })
+  console.log('\nScheduling jobs:\n', { scheduledJobs })
 }
 
 export default schedule

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,8 @@
     "domain-logic": "link:../domain-logic",
     "next": "11.0.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-use-websocket": "^2.7.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/ui/pages/websocket.tsx
+++ b/ui/pages/websocket.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useCallback, useMemo, useRef } from 'react'
+import useWebSocket, { ReadyState } from 'react-use-websocket'
+
+export default function WebsocketPage() {
+  //Public API that will echo messages sent to it back to the client
+  const [socketUrl, setSocketUrl] = useState('ws://localhost:3001/ws/someDomain/someAction');
+  const messageHistory = useRef([]);
+
+  const {
+    sendMessage,
+    lastMessage,
+    readyState,
+  } = useWebSocket(socketUrl);
+
+  messageHistory.current = useMemo(() =>
+    messageHistory.current.concat(lastMessage),[lastMessage]);
+
+  const handleClickChangeSocketUrl = useCallback(() =>
+    setSocketUrl('ws://localhost:3001/ws/someDomain/someAction'), []);
+
+  const handleClickSendMessage = useCallback(() =>
+    sendMessage('Hello'), []);
+
+  const connectionStatus = {
+    [ReadyState.CONNECTING]: 'Connecting',
+    [ReadyState.OPEN]: 'Open',
+    [ReadyState.CLOSING]: 'Closing',
+    [ReadyState.CLOSED]: 'Closed',
+    [ReadyState.UNINSTANTIATED]: 'Uninstantiated',
+  }[readyState];
+
+  return (
+    <div>
+      <button className="p-1 px-2 rounded border hover:border-red-700 dark:hover:border-green-500 border-transparent text-current border-red-600 dark:border-green-600"
+        onClick={handleClickChangeSocketUrl}
+      >
+        Click Me to change Socket Url
+      </button>
+      <button className="p-1 px-2 rounded border hover:border-red-700 dark:hover:border-green-500 border-transparent text-current border-red-600 dark:border-green-600"
+        onClick={handleClickSendMessage}
+        disabled={readyState !== ReadyState.OPEN}
+      >
+        Click Me to send 'Hello'
+      </button>
+      <span>The WebSocket is currently {connectionStatus}</span>
+      {lastMessage ? <span>Last message: {lastMessage.data}</span> : null}
+      <ul>
+        {messageHistory.current
+          .map((message, idx) => <span key={idx}>{message ? message.data : null}</span>)}
+      </ul>
+    </div>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,6 +2577,14 @@ fastify-warning@^0.2.0:
   resolved "https://registry.yarnpkg.com/fastify-warning/-/fastify-warning-0.2.0.tgz#e717776026a4493dc9a2befa44db6d17f618008f"
   integrity sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==
 
+fastify-websocket@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fastify-websocket/-/fastify-websocket-3.2.0.tgz#69421740671cec95f2001a9dccd393c923d482c0"
+  integrity sha512-O1I04Y6aV2rkO+RRMYQzIe2h7omA20p+Nk/HAdJmfHvNErY7OCani06+rDMmQCKYbZT6RWrsy13U+GrJPhSO6Q==
+  dependencies:
+    fastify-plugin "^3.0.0"
+    ws "^7.4.2"
+
 fastify@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/fastify/-/fastify-3.19.0.tgz#05b8c1d388fced9243528209a60ccbfa9d5e1aa8"
@@ -4810,6 +4818,11 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-use-websocket@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/react-use-websocket/-/react-use-websocket-2.7.1.tgz#51e4798aa4e328595b86e63b9d667ae2114eed1b"
+  integrity sha512-n0H429jQGaZAnn8BJljCcAgeSezXYzTLO0tb5QvdZnNjhAA8Br3A3GjU5ziNMlxant++Iv/IRQRNMKCfWnsHrQ==
+
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -5901,7 +5914,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6:
+ws@^7.4.2, ws@^7.4.6:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==


### PR DESCRIPTION
The goal of this PR is to figure out how (and if) we will add websockets capabilities.

The approach so far is:
* Get a websocket endpoint on our stateful server (the fastify used for jobs execution)
* Add a React plugin to handle websocket state on the client side

TODO:
- [ ] Understand how much of the complexity we can hide away inside the action interface (`run` using transport `websocket`).
- [x] Is this approach desirable for a first release when compared with SWR polling?
- [ ] If we decide to go forward with websockets define some helper functions creating a first layer of abstraction to connect domain logic with websocket transport and use it in a fully functioning example.