### PR TITLE
Fix GetStaticProps with dates

### DIFF
--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -37,7 +37,8 @@ export default function TodosPage({
 }
 
 export const getStaticProps = async () => {
-  const initialData = await stories.all.run()
+  const storyList = await stories.all.run()
+  const initialData = storyList.map((story) => ({...story, createdAt: story.createdAt.toISOString()}))
 
   return {
     props: { initialData },


### PR DESCRIPTION
Using superjson prooved to be too much of a hassle to fix just one small issue. We will attack the problem with a less intrusive approach, just convering dates to string before sending them to the static props.