### PR TITLE
Hide approved stories from the backlog

### DIFF
--- a/domain-logic/stories/__tests__/all.test.ts
+++ b/domain-logic/stories/__tests__/all.test.ts
@@ -1,0 +1,50 @@
+import { stories } from 'stories'
+import { getPrisma, clearDatabase } from 'db'
+
+const all = stories.all
+
+describe('all', () => {
+  beforeEach(clearDatabase)
+  afterAll(async () => {
+    await getPrisma().$disconnect()
+  })
+
+  it('show one story pending when there are no scenarios', async () => {
+    const story = await getPrisma().story.create({
+      data: { asA: 'user', iWant: 'to', soThat: 'I can test' },
+    })
+
+    const stories = await all.run()
+
+    expect(stories[0].state).toBe('pending')
+  })
+
+  it('show one story pending when there is one scenario without approval', async () => {
+    const story = await getPrisma().story.create({
+      data: { asA: 'user', iWant: 'to', soThat: 'I can test' },
+    })
+    await getPrisma().scenario.create({
+      data: { storyId: story.id, description: 'test scenario to be approved' },
+    })
+
+    const stories = await all.run()
+
+    expect(stories[0].state).toBe('pending')
+  })
+
+  it('show one story approved when there are only approved scenarios', async () => {
+    const story = await getPrisma().story.create({
+      data: { asA: 'user', iWant: 'to', soThat: 'I can test' },
+    })
+    const scenario = await getPrisma().scenario.create({
+      data: { storyId: story.id, description: 'test scenario to be approved' },
+    })
+    await getPrisma().scenarioApproval.create({
+      data: { scenarioId: scenario.id },
+    })
+
+    const stories = await all.run()
+
+    expect(stories[0].state).toBe('approved')
+  })
+})

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -41,23 +41,25 @@ export default function HomePage() {
           id="backlog"
           className="flex-grow flex flex-col w-full border border-gray-800 dark:border-gray-700 border-opacity-20 divide-y divide-gray-800 dark:divide-gray-700 divide-opacity-20"
         >
-          {data?.map((story, idx) => (
-            <StoryItem
-              key={story.id}
-              story={story}
-              setEditing={setEditing}
-              onClickBefore={changePosition(
-                story.id,
-                'before',
-                data[idx - 1]?.id
-              )}
-              onClickAfter={changePosition(
-                story.id,
-                'after',
-                data[idx + 1]?.id
-              )}
-            />
-          ))}
+          {data
+            ?.filter((story) => story.state == 'pending')
+            .map((story, idx) => (
+              <StoryItem
+                key={story.id}
+                story={story}
+                setEditing={setEditing}
+                onClickBefore={changePosition(
+                  story.id,
+                  'before',
+                  data[idx - 1]?.id
+                )}
+                onClickAfter={changePosition(
+                  story.id,
+                  'after',
+                  data[idx + 1]?.id
+                )}
+              />
+            ))}
         </div>
       </main>
       <FooterInfo />


### PR DESCRIPTION
We let the database calculate the story state based on scenario approvals and return that as a new story attribute to the front-end