### PR TITLE
ensure no scenario approval before development

### DIFF
--- a/ui/components/__test__/scenarios.test.tsx
+++ b/ui/components/__test__/scenarios.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { Scenario, Story } from 'domain-logic/stories'
+
+import Scenarios from '../scenarios'
+
+const draftWithScenariosStory: Story =
+{
+  id: 'draft-story-1',
+  asA: 'developer',
+  iWant: 'see the stories list',
+  soThat: 'I have confidence',
+  state: 'draft_with_scenarios',
+  createdAt: new Date(),
+}
+
+const draftStory: Story =
+{
+  id: 'draft-story-1',
+  asA: 'developer',
+  iWant: 'see the stories list',
+  soThat: 'I have confidence',
+  state: 'draft',
+  createdAt: new Date(),
+}
+
+const developmentStory: Story =
+{
+  id: 'draft-story-1',
+  asA: 'developer',
+  iWant: 'see the stories list',
+  soThat: 'I have confidence',
+  state: 'development',
+  createdAt: new Date(),
+}
+
+jest.mock('domain-logic/stories', () => ({
+  ...jest.requireActual('domain-logic/stories'),
+  stories: { storyScenarios: { run: jest.fn() } },
+}))
+
+jest.mock('swr', () => {
+  return () => {
+    const scenario: Scenario = {
+      id: 'some id',
+      storyId: 'some-story-id',
+      createdAt: new Date(),
+      description: 'given a scenario',
+      approved: false
+    }
+
+    return { data: [scenario] }
+  }
+})
+
+describe(Scenarios, () => {
+  it('renders scenarios form', () => {
+    render(<Scenarios story={draftStory} />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('renders scenarios list', () => {
+    render(<Scenarios story={draftWithScenariosStory} />)
+    expect(screen.getByText('given a scenario')).toBeInTheDocument()
+  })
+
+  it('renders scenarios list without approve button when story is in draft', () => {
+    render(<Scenarios story={draftWithScenariosStory} />)
+    expect(screen.queryByRole('button', { name: '✔' })).not.toBeInTheDocument()
+  })
+
+  it('renders scenarios list with approve button when story is in development', () => {
+    render(<Scenarios story={developmentStory} />)
+    expect(screen.getByRole('button', { name: '✔' })).toBeInTheDocument()
+  })
+})
+
+

--- a/ui/components/scenarios.tsx
+++ b/ui/components/scenarios.tsx
@@ -55,21 +55,20 @@ export default function Scenarios({ story }: Props) {
       </form>
       {data?.map((scenario) => (
         <div
-          className="pb-2 m-4 text-sm border-b last:border-b-0"
+          className="pb-2 m-4 text-sm border-b last:border-b-0 flex flex-row bg-gray-500 bg-opacity-50"
           key={scenario.id}
         >
-          <p className={cx(scenario.approved && 'text-green-500')}>
-            <pre>{scenario.description}</pre>
+          {story.state === 'development' &&
+            <button
+              onClick={approveScenario(scenario.id)}
+              className="text-lg text-green-600"
+            >
+              ✔
+            </button>
+          }
+          <p className={cx(scenario.approved && 'text-green-500', 'ml-3')}>
+            {scenario.description}
           </p>
-          <p className="mt-2 text-xs text-right text-gray-900 text-opacity-60 dark:text-white dark:text-opacity-50">
-            {scenario.createdAt.toLocaleDateString()}
-          </p>
-          <button
-            onClick={approveScenario(scenario.id)}
-            className="text-lg text-green-600"
-          >
-            ✔
-          </button>
         </div>
       ))}
     </>

--- a/ui/components/scenarios.tsx
+++ b/ui/components/scenarios.tsx
@@ -5,7 +5,6 @@ import { useForm, SubmitHandler } from 'react-hook-form'
 import type { Scenario } from 'domain-logic/stories'
 import { isEmpty } from 'lodash'
 import { cx } from '@/lib/utils'
-import type { MutatorCallback } from 'swr/dist/types'
 
 type Props = { story: Story }
 type Inputs = Pick<Scenario, 'description'>
@@ -15,7 +14,7 @@ export default function Scenarios({ story }: Props) {
   const { data } = useSWR(swrKey, () =>
     stories.storyScenarios.run({ id: story.id })
   )
-  const { register, reset, setFocus, handleSubmit, formState } =
+  const { register, reset, handleSubmit, formState } =
     useForm<Inputs>()
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {


### PR DESCRIPTION
- Remove some unnecessary code
- Show approve button only for stories in development since it makes no sense to approve a scenario before working on it
- Add some test coverage for Scenarios component
